### PR TITLE
example14: checked how autowire=byName works for UserInfo entity

### DIFF
--- a/src/main/java/com/luxoft/springioc/example14/Main.java
+++ b/src/main/java/com/luxoft/springioc/example14/Main.java
@@ -14,8 +14,8 @@ public class Main {
 //		UserDirectorySearch userDirectorySearch = (UserDirectorySearch) context.getBean("userDirectorySearch");
 //		System.out.println(userDirectorySearch.getUserDirectory().getClass().getSimpleName());
 
-//		UserInfo userInfo = (UserInfo) context.getBean("userInfo");
-//		System.out.println(userInfo.getLdapUserDirectory().getClass().getName());
+		UserInfo userInfo = (UserInfo) context.getBean("userInfo");
+		System.out.println(userInfo.getLdapUserDirectory().getClass().getName());
 //
 //		System.out.println(loginManager.getUserDirectory() == userDirectorySearch.getUserDirectory());
 //		System.out.println(userInfo.getLdapUserDirectory().getClass().getSimpleName());

--- a/src/main/java/com/luxoft/springioc/example14/UserInfo.java
+++ b/src/main/java/com/luxoft/springioc/example14/UserInfo.java
@@ -2,7 +2,8 @@ package com.luxoft.springioc.example14;
 
 public class UserInfo
 {
-    private LDAPUserDirectory ldapUserDirectory;
+//    private LDAPUserDirectory ldapUserDirectory;
+    private UserDirectory ldapUserDirectory;
 
     public UserDirectory getLdapUserDirectory()
     {

--- a/src/main/resources/example14/application-context.xml
+++ b/src/main/resources/example14/application-context.xml
@@ -7,7 +7,7 @@
 
 	<!--<bean id="ud" class="com.luxoft.springioc.example14.LDAPUserDirectory" />-->
 
-	<bean id="uasdd" class="com.luxoft.springioc.example14.LDAPUserDirectory" />
+	<bean id="ldapUserDirectory" class="com.luxoft.springioc.example14.LDAPUserDirectory" />
 
 	<bean id="userDirectory" class="com.luxoft.springioc.example14.DatabaseUserDirectory" />
 
@@ -17,8 +17,8 @@
 	<!--<bean id="userDirectorySearch" class="com.luxoft.springioc.example14.UserDirectorySearch"-->
 		<!--autowire="byName" />-->
 
-	<!--<bean id="userInfo" class="com.luxoft.springioc.example14.UserInfo"-->
-		<!--autowire="byType" >-->
+	<bean id="userInfo" class="com.luxoft.springioc.example14.UserInfo"
+		autowire="byName" />
 
 		<!--<property name="ldapUserDirectory" ref="userDirectory" />-->
 	<!--</bean>-->


### PR DESCRIPTION
1. Если изменять  значение атрибута autowire на byName, то нужно проверить, что есть бин с id =названием поля в классе UserInfo, иначе autowire не сработает, потому что оно ищет по имени.
2. Если заменить класс поля на родительский класс в классе UserInfo, то autowire всё равно сработает, даже если в application-context.xml будет указан бин дочернего класса, но с подходящим id